### PR TITLE
Update the left nav to open in new tab

### DIFF
--- a/website/_data/nav.yaml
+++ b/website/_data/nav.yaml
@@ -6,16 +6,20 @@
   submenu:
 
     - title: Search (OPUS)
-      href: /search/
+      href: //opus.pds-rings.seti.org/opus/
+      open: new_tab
 
     - title: Browse Data Volumes
       href: /viewmaster/volumes/
+      open: new_tab
 
     - title: Quick Downloads
       href: /viewmaster/archives-volumes/
+      open: new_tab
 
     - title: PDS-Wide Search
       href: //pds.nasa.gov/datasearch/data-search/
+      open: new_tab
 
 - title: Node Resources
   href: /
@@ -89,12 +93,16 @@
 
     - title: Matt Tiscareno
       href: //www.seti.org/our-scientists/matthew-tiscareno
+      open: new_tab
 
     - title: Mitch Gordon
       href: //www.seti.org/our-scientists/mitchell-gordon
+      open: new_tab
 
     - title: Mark Showalter
       href: //www.seti.org/our-scientists/mark-showalter
+      open: new_tab
 
     - title: Rob French
       href: //www.seti.org/our-scientists/robert-french
+      open: new_tab

--- a/website/_includes/nav.html
+++ b/website/_includes/nav.html
@@ -12,7 +12,7 @@
       <b>&nbsp;&nbsp;&nbsp;<input type=submit class="button" value="Questions/Feedback"></b>
       </form>
     </p>
-    
+
     {% for section in site.data.nav %}
 
     <li class="subheading">
@@ -31,8 +31,10 @@
             {% if menu_url_path_split[1] == page_url_path_split[1] %}
               class = "active"
             {% endif %}
-          >
-            <a href = "{{ item.href }}">{{ item.title }}</a>
+            >
+            <a href = "{{ item.href }}"
+            {% if item.open contains 'new_tab' %}target="_blank"{% endif %}
+            >{{ item.title }}</a>
 
           </li>
 


### PR DESCRIPTION
When a link is not pds-website specific, open in new tab.  The first 4 items in the left nav need to open in a new tab.  This is an ongoing cleanup issue.