### PR TITLE
Updated the pds nav bar code

### DIFF
--- a/website/assets/pds-app-bar/pds-app-bar.css
+++ b/website/assets/pds-app-bar/pds-app-bar.css
@@ -24,6 +24,7 @@
     color: #f5f5f6;
     background: #000;
     box-sizing: content-box;
+    border-bottom: 3px solid rgb(245,245,246, 0.5);
 }
 
 #pds-app-bar * {
@@ -57,11 +58,9 @@
     font-size: 14px;
     padding: 8px 5px;
 }
-#pds-app-bar-dropdown > a:hover {
-    background-color: #171717;
-}
+
 #pds-app-bar-dropdown > a > span {
-    margin-left: 35px;
+    margin-left: 0.5em;
 }
 #pds-app-bar-dropdown > a > span:after {
     display: inline-flex;
@@ -96,6 +95,7 @@
     -webkit-transition: all 100ms ease;
        -moz-transition: all 100ms ease;
             transition: all 100ms ease;
+    outline: none !important;
 }
 
 #pds-app-bar-dropdown > ul {
@@ -107,16 +107,14 @@
     padding: 7px 0;
     font-size: 12px;
 }
-#pds-app-bar-dropdown > ul li:hover > a {
+#pds-app-bar-dropdown > ul li:hover > a,
+#pds-app-bar-dropdown > ul li:focus > a  {
     color: #64b6f7;
 }
 
-#pds-app-bar-info {
-    margin-right: 14px;
-}
 #pds-app-bar-info > img {
-    width: 20px;
-    height: 20px;
+    width: 16px;
+    height: 16px;
 }
 #pds-app-bar-info > div {
     z-index: 1000;
@@ -126,11 +124,8 @@
     max-width: 580px;
 }
 
-/* tabbable items */
-#pds-app-bar-title:focus,
-#pds-app-bar-info:focus,
-#pds-app-bar-dropdown > a:focus,
+/* tabbable items
 #pds-app-bar-dropdown > ul li:focus {
     outline: #005fcc auto 1px;
     outline: -webkit-focus-ring-color auto 1px;
-}
+} */


### PR DESCRIPTION
•	Added a gray bar below the nav bar to allow for some visual differentiation between the nav and site contents
•	Moved the information (i) icon and the dropdown/dropup arrows closer to the associated element so the association was more specific and obvious
•	Added a ‘hover’ ability, such that when the mouse pointer object hovers over the “Find a Node” element, the menu will drop down.  The menu will collapse when the mouse pointer object hovers out of the menu area
•	Clicking on the up/down arrow will expand/collapse the menu
•	Menu items are now left aligned for a cleaner visual interface
•	When a node is selected, the menu on the original page collapses and the selected node is unhighlighted, leaving the menu back in its original default state
•	Removed the outlines when you click on the (i) icon and additional menu elements, as they were visually distracting and not consistent among all the different browsers and in some cases the outline was partially obscured by the dropdown.