### PR TITLE
galleries.html updated for new galleries

### DIFF
--- a/website/galleries.html
+++ b/website/galleries.html
@@ -8,34 +8,44 @@ title: "Press Release Image Galleries"
 
 # <strong>NASA Press Release Image Galleries</strong>
 
-## By Target Planetary System
+## By Planetary System
 
-  * [Jupiter](/galleries/target_jupiter.html)
-  * [Saturn](/galleries/target_saturn.html)
-  * [Uranus](/galleries/target_uranus.html)
-  * [Neptune](/galleries/target_neptune.html)
-  * [Pluto](/galleries/target_pluto.html)
-  * [Mars](/galleries/mars.html) (planet only)
-  * [Phobos and Deimos](/galleries/target_phobos.html)
+  * [Mercury](/galleries/mercury.html)
+  * [Venus](/galleries/venus.html)
+  * Mars by [date](/galleries/mars.html) or [target](/galleries/target_mars.html)
+  * Jupiter by [date](/galleries/jupiter.html) or [target](/galleries/target_jupiter.html)
+  * Saturn by [date](/galleries/saturn.html) or [target](/galleries/target_saturn.html)
+  * Uranus by [date](/galleries/uranus.html) or [target](/galleries/target_uranus.html)
+  * Neptune by [date](/galleries/neptune.html) or [target](/galleries/target_neptune.html)
+  * Pluto by [date](/galleries/pluto.html) or [target](/galleries/target_pluto.html)
 
-## By Mission - each sorted chronologically
+## By Target Type
 
-  * [Cassini](/galleries/cassini.html)
-  * [Galileo](/galleries/galileo.html)
-  * [Juno](/galleries/juno.html)
-  * [New Horizons](/galleries/new_horizons.html)
-  * [Dawn](/galleries/dawn.html)
-  * [MESSENGER](/galleries/messenger.html)
+  * Asteroids by [date](/galleries/asteroids.html) or [target](/galleries/asteroid_1_ceres.html)
+  * Comets by [date](/galleries/comets.html) or [target](/galleries/comet_1p_halley.html)
+  * Kuiper Belt objects by [date](/galleries/kbos.html) or [target](/galleries/kbo_pluto.html)
+  * Exoplanetary systems by [date](/galleries/exoplanets.html) or [target](/galleries/exoplanet_55_cancri.html)
 
-## By Mission plus Target System - each sorted chronologically
+## By Mission
 
-  * [Cassini at Jupiter](/galleries/cassini_jupiter.html)
-  * [Cassini at Saturn](/galleries/cassini_saturn.html)
+  * [Voyager](/galleries/voyager.html) to Jupiter, Saturn, Uranus, and Neptune
+  * [Galileo](/galleries/galileo.html) to Jupiter
+  * [Cassini](/galleries/cassini.html) to Jupiter and Saturn
+  * [New Horizons](/galleries/new_horizons.html) to Jupiter, Pluto, and 486958 Arrokoth
+  * [Juno](/galleries/juno.html) to Jupiter
+  * [Dawn](/galleries/dawn.html) to 4 Vesta and 1 Ceres
+  * [MESSENGER](/galleries/messenger.html) to Mercury
+  * [Rosetta](/galleries/rosetta.html) to 67P/Churyumov–Gerasimenko
+
+## By Mission and System
+
   * [Voyager at Jupiter](/galleries/voyager_jupiter.html)
   * [Voyager at Saturn](/galleries/voyager_saturn.html)
   * [Voyager at Uranus](/galleries/voyager_uranus.html)
   * [Voyager at Neptune](/galleries/voyager_neptune.html)
+  * [Cassini at Jupiter](/galleries/cassini_jupiter.html)
+  * [Cassini at Saturn](/galleries/cassini_saturn.html)
 
-## Omnibus - Every NASA press release archived in the PDS sorted chronologically
+## Omnibus - Every planetary press release from NASA
 
   * [Everything](/galleries/all.html)


### PR DESCRIPTION
These are the changes to galleries.html for the gallery update. The new gallery files are already deployed, but gallery.html is part of this repo. Please review. BTW, the jekyll files previously managed in the website_galleries subdirectory are now managed inside the SETI/pds-galleries repo instead.