### PR TITLE
Cassini ISS About page has broken links #115, partial 110 organize assets update folders

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -8,6 +8,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 # twitter_username: jekyllrb
 # github_username:  jekyll
 opus_url: "//opus.pds-rings.seti.org/opus/#"
+holdings_url: "//pds-rings.seti.org/holdings/"
 
 # Build settings
 markdown: kramdown

--- a/website/cassini/cirs/about.html
+++ b/website/cassini/cirs/about.html
@@ -3,14 +3,14 @@ layout: base
 layout_style: default
 tabs: cassini_cirs
 ---
-  
+
 ## About CIRS Data
 
 ### 1\. Significant Updates.
 
-  * **In January 2010,** we replaced version 1 of the CIRS data set (COCIRS_0nnn) with version 2. 
+  * **In January 2010,** we replaced version 1 of the CIRS data set (COCIRS_0nnn) with version 2.
 
-  * **In April 2010,** we regenerated the entire reformatted CIRS dataset (COCIRS_5nnn) using the version 2 data. 
+  * **In April 2010,** we regenerated the entire reformatted CIRS dataset (COCIRS_5nnn) using the version 2 data.
 
 The deliveries of version 1 were made quarterly over the span of several
 years. During that time the CIRS team made incremental adjustments in the
@@ -29,31 +29,33 @@ much closer to zero, and many anomalies and artifacts have disappeared.
 Another consequence is that there is not an exact one-to-one correspondence
 between files in version 1 and version 2.
 
-  * **In January 2011**, the entire reformatted data set was regenerated again in order to clean up minor errors mostly relating to documentation. No significant changes were made to the data files which had been generated in or subsequent to the the major revision in April 2010. The January 2011 version is considered stable pending a follow-up review by the original peer review panel. 
+  * **In January 2011**, the entire reformatted data set was regenerated again in order to clean up minor errors mostly relating to documentation. No significant changes were made to the data files which had been generated in or subsequent to the the major revision in April 2010. The January 2011 version is considered stable pending a follow-up review by the original peer review panel.
 
-  * **In July 2011**, the CIRS team again redelivered their entire data set, this time as version 3.1. On line, we replaced version 2 of the CIRS data set with version 3.1. 
+  * **In July 2011**, the CIRS team again redelivered their entire data set, this time as version 3.1. On line, we replaced version 2 of the CIRS data set with version 3.1.
 
     * The version 3.1 release incorporates a further refinement in the calibration algorithm.For interferograms collected using CIRS Flight Software Version 6 (executed in July of 2010), non-co-added data will have the 1/2 Hz noise spikes suppressed while no noise spike suppression will be done on co-added data.
 
-    * In addition several changes to the contents of the data files were made. These changes necessitate modifications to our reformatting pipeline software which we are in the process of making. 
+    * In addition several changes to the contents of the data files were made. These changes necessitate modifications to our reformatting pipeline software which we are in the process of making.
 
-  * **In January 2015, the CIRS team again redelivered the Saturn encounter data (volumes COCIRS_0401 and higher); this time as version 3.2. On line, we replaced version 3.1 of the CIRS data set with version 3.2**. 
+  * **In January 2015, the CIRS team again redelivered the Saturn encounter data (volumes COCIRS_0401 and higher); this time as version 3.2. On line, we replaced version 3.1 of the CIRS data set with version 3.2**.
 
-    * The version 3.2 release incorporates further refinements in the calibration algorithm and corrects some errors in that pipeline. 
+    * The version 3.2 release incorporates further refinements in the calibration algorithm and corrects some errors in that pipeline.
 
-    * The version 3.2 release also includes new, highly derived products in the /DATA/CUBE directory tree of each volume. 
+    * The version 3.2 release also includes new, highly derived products in the /DATA/CUBE directory tree of each volume.
 
   * **In early May 2016, the CIRS team again redelivered the Saturn encounter data (volumes COCIRS_0401 and higher)**.
-   
-    * The primary data set, CO-S-CIRS-2/3/4-TSDR-V3.2 remains unchanged.  
-    
-    * The data set of highly derived products, CO-S-CIRS-5-CUBES-V1.0, contains numerous corrections over the original delivery. 
 
-  * **In April 2018, the CIRS team again redelivered the Saturn encounter data (volumes COCIRS_0401 and higher)**. 
+    * The primary data set, CO-S-CIRS-2/3/4-TSDR-V3.2 remains unchanged.
+
+    * The data set of highly derived products, CO-S-CIRS-5-CUBES-V1.0, contains numerous corrections over the original delivery.
+
+  * **In April 2018, the CIRS team again redelivered the Saturn encounter data (volumes COCIRS_0401 and higher)**.
 
     * The primary data set, CO-S-CIRS-2/3/4-TSDR-V4.0, and the data set of highly derived products, CO-S-CIRS-5-CUBES-V2.0, reflect changes to several calibration routines.
 
-    * For a complete list of changes in versions 2, 3 and 4, see the end of the <a href="orig_DATASET.TXT" target="_blank">DATASET.CAT</a> file. Identical copies of this file are in the CATALOG directory of each volume.
+    * For a complete list of changes in versions 2, 3 and 4, see the end of the [DATASET.CAT](orig_DATASET.TXT){:target="_blank"} file. Identical copies of this file are in the CATALOG directory of each volume.
+
+[DATASET.CAT]({{ site.holdings_url }}volumes/COCIRS_0xxx/COCIRS_0010/CATALOG/DATASET.CAT){:target="_blank"}
 
   * **In the meantime, the reformatted volumes remain based on version 2 of the data, and new volumes, beginning with COCIRS_1007, currently are available only in the original format**.
 
@@ -67,9 +69,9 @@ between files in version 1 and version 2.
 
 **Cassini CIRS Data User Guide**.
 
-  * **May 2017.** An updated version of the **<a href="/cassini/cirs/CIRS-User-Guide_v11.6-5-3-17.pdf" target="_blank">CIRS User Guide</a>** is available. 
+  * The **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from RMS Viewmaster holdings.
 
-**Users are strongly encouraged to review a CIRS <a href="aareadme.txt" target="_blank">aareadme.txt</a> file.** This file appears in the root directory of every volume. (Some of the header information in the aareadme.txt files varies from one volume to the next, but the body of information in the files is the same.) 
+**Users are strongly encouraged to review a CIRS [aareadme.txt]({{ site.holdings_url }}volumes/COCIRS_1xxx/COCIRS_1709/AAREADME.TXT){:target="_blank"} file.** This file appears in the root directory of every volume. (Some of the header information in the aareadme.txt files varies from one volume to the next, but the body of information in the files is the same.)
 
 Further details of the CIRS archive volumes and calibration procedures can be
 found in the DOCUMENT directory of each volume. However the bulk of this

--- a/website/cassini/cirs/about.html
+++ b/website/cassini/cirs/about.html
@@ -53,9 +53,7 @@ between files in version 1 and version 2.
 
     * The primary data set, CO-S-CIRS-2/3/4-TSDR-V4.0, and the data set of highly derived products, CO-S-CIRS-5-CUBES-V2.0, reflect changes to several calibration routines.
 
-    * For a complete list of changes in versions 2, 3 and 4, see the end of the [DATASET.CAT](orig_DATASET.TXT){:target="_blank"} file. Identical copies of this file are in the CATALOG directory of each volume.
-
-[DATASET.CAT]({{ site.holdings_url }}volumes/COCIRS_0xxx/COCIRS_0010/CATALOG/DATASET.CAT){:target="_blank"}
+    * For a complete list of changes in versions 2, 3 and 4, see the end of the [DATASET.CAT]({{ site.holdings_url }}volumes/COCIRS_1xxx/COCIRS_1001/CATALOG/DATASET.CAT){:target="_blank"} file. Identical copies of this file are in the CATALOG directory of each volume.
 
   * **In the meantime, the reformatted volumes remain based on version 2 of the data, and new volumes, beginning with COCIRS_1007, currently are available only in the original format**.
 
@@ -69,7 +67,7 @@ between files in version 1 and version 2.
 
 **Cassini CIRS Data User Guide**.
 
-  * The **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from RMS Viewmaster holdings.
+  * The **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from the PDS Ring-Moon Systems Node holdings.
 
 **Users are strongly encouraged to review a CIRS [aareadme.txt]({{ site.holdings_url }}volumes/COCIRS_1xxx/COCIRS_1709/AAREADME.TXT){:target="_blank"} file.** This file appears in the root directory of every volume. (Some of the header information in the aareadme.txt files varies from one volume to the next, but the body of information in the files is the same.)
 

--- a/website/cassini/cirs/index.html
+++ b/website/cassini/cirs/index.html
@@ -20,7 +20,7 @@ formats.
 
 **Cassini CIRS Data User Guide**.
 
-  * **May 2017.** An updated version of the **<a href="/cassini/cirs/CIRS-User-Guide_v11.6-5-3-17.pdf" target="_blank">CIRS User Guide</a>** is available. 
+  * The **[CIRS User Guide](/holdings/documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from RMS Viewmaster holdings. 
 
 ###  The CIRS Tabs
 
@@ -30,4 +30,3 @@ obtain and use them.
   * [About CIRS Data](about.html) \- Organization of the archive and links to key documents.
   * [Access Original Format Data](access_orig.html) \- Links to the original data volumes (Jupiter and Saturn encounters).
   * [Access Re-formatted Data](access_reform.html) \- Links to the re-formatted data volumes (Saturn encounter only)
-

--- a/website/cassini/cirs/index.html
+++ b/website/cassini/cirs/index.html
@@ -20,7 +20,7 @@ formats.
 
 **Cassini CIRS Data User Guide**.
 
-  * The **[CIRS User Guide](/holdings/documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from RMS Viewmaster holdings. 
+  * The **[CIRS User Guide](/holdings/documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** is available from the PDS Ring-Moon Systems Node holdings. 
 
 ###  The CIRS Tabs
 

--- a/website/cassini/cirs/orig_about.html
+++ b/website/cassini/cirs/orig_about.html
@@ -1,6 +1,7 @@
 ---
 layout: base
 layout_style: default
+tabs: cassini_cirs
 title: "Introduction to CIRS Data"
 ---
 
@@ -9,8 +10,8 @@ title: "Introduction to CIRS Data"
   * [Finding Data](orig_finding.html)
   * [Documentation](orig_doc.html)
 
-  
-** Users are strongly encouraged to review a CIRS <a href="orig_AAREADME.TXT" target="_blank">AAREADME.TXT</a> file.** This file appears in the root directory of every volume. 
+
+** Users are strongly encouraged to review a CIRS <a href="orig_AAREADME.TXT" target="_blank">AAREADME.TXT</a> file.** This file appears in the root directory of every volume.
 
 ###  1\. Introduction to CIRS Data
 
@@ -75,4 +76,3 @@ documentation and examples.
   * Return to [About CIRS Data](about.html)
 
   * Go to information [about the re-formatted CIRS data](reform_about.html)
-

--- a/website/cassini/cirs/orig_about.html
+++ b/website/cassini/cirs/orig_about.html
@@ -11,12 +11,11 @@ title: "Introduction to CIRS Data"
   * [Documentation](orig_doc.html)
 
 
-** Users are strongly encouraged to review a CIRS <a href="orig_AAREADME.TXT" target="_blank">AAREADME.TXT</a> file.** This file appears in the root directory of every volume.
+** Users are strongly encouraged to review a CIRS [aareadme.txt]({{ site.holdings_url }}volumes/COCIRS_1xxx/COCIRS_1709/AAREADME.TXT){:target="_blank"} file.** This file appears in the root directory of every volume.
 
 ###  1\. Introduction to CIRS Data
 
-For full details about the CIRS instrument, see
-<a href="INST.txt" target="_blank">COCIRS_xxxx/CATALOG/INST.CAT</a>: an INST.CAT file.
+For full details about the CIRS instrument, see [COCIRS_0xxx/COCIRS_0xxx/CATALOG/INST.CAT]({{ site.holdings_url }}volumes/COCIRS_0xxx/COCIRS_0010/CATALOG/INST.CAT){:target="_blank"}: an INST.CAT file.
 
 The CIRS instrument has several unusual properties, which have made the CIRS
 data particularly challenging to work with:
@@ -62,7 +61,7 @@ for all of the Saturn encounter data
 
 ###  2\. Software
 
-The [SOFTWARE](SOFTWARE/) directory on each volume contains subdirectories
+The [SOFTWARE]({{ site.holdings_url }}volumes/COCIRS_1xxx/COCIRS_1001/SOFTWARE){:target="_blank"} directory on each volume contains subdirectories
 providing both binary (Solaris and Linux) and source code for the data
 analysis tool, Vanilla, as well as a substantial amount of Vanilla related
 documentation and examples.
@@ -71,7 +70,7 @@ documentation and examples.
 
   * Use the tabs at the top of this page to obtain more information about the original format CIRS data.
 
-  * Access [ the original format data](access_orig.html)
+  * Access [the original format data](access_orig.html)
 
   * Return to [About CIRS Data](about.html)
 

--- a/website/cassini/enhanced.html
+++ b/website/cassini/enhanced.html
@@ -31,9 +31,9 @@ established as an overall clearing house for Cassini support.
   * **Preview Product Keys**
 
     * Image previews are tinted based on filter(s) used - from violet for relatively short wavelengths to red for relatively long wavelengths.
-    * **[Key for Cassini CIRS previews](/cassini/cirs/COCIRS_previews.txt){:target="_blank"}**
-    * **[Key for Cassini UVIS previews](/cassini/uvis/UVIS_previews.txt){:target="_blank"}**
-    * **[Key for Cassini VIMS previews](/cassini/vims/VIMS-Preview-Interpretation-Guide.pdf){:target="_blank"}**
+    * **[Key for Cassini CIRS previews]({{ site.holdings_url }}documents/COCIRS_5xxx/CIRS-Diagram-Interpretation-Guide.txt){:target="_blank"}**
+    * **[Key for Cassini UVIS previews]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Preview-Interpretation-Guide.txt){:target="_blank"}**
+    * **[Key for Cassini VIMS previews]({{ site.holdings_url }}/documents/COVIMS_0xxx/VIMS-Preview-Interpretation-Guide.pdf){:target="_blank"}**
 <p></p>
   * **Calibrated ISS images**
 
@@ -50,10 +50,10 @@ established as an overall clearing house for Cassini support.
 <p></p>
   * **New or updated data user's guides**
 
-    * **[CIRS Data User Guide](/cassini/cirs/CIRS-User-Guide_v11.6-5-3-17.pdf){:target="_blank"}** - updated in May 2017.
-    * **[ISS Data User's Guide](/cassini/iss/iss_data_user_guide_180916.pdf){:target="_blank"}** - updated in September 2018.
+    * **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}**.
+    * **[ISS Data User's Guide]({{ site.holdings_url }}documents/COISS_0xxx/ISS-Users-Guide.pdf){:target="_blank"}** - updated in September 2018.
     * **[RSS Data User Guide](/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** - released in September 2018.
-    * **[UVIS User's Guide](/cassini/uvis/1-UVIS_Users_Guide_-2018-Jan 15-For PDS-REV-2018-07-06.pdf){:target="_blank"}** - updated in July 2018.
+    * **[UVIS User's Guide]({{ site.holdings_url }}documents/COUVIS_8xxx/UVIS-Users-Guide.pdf){:target="_blank"}** - updated in July 2018.
 <p></p>
   * **Downloadable tables of enhanced geometric metadata**
 

--- a/website/cassini/enhanced.html
+++ b/website/cassini/enhanced.html
@@ -50,10 +50,10 @@ established as an overall clearing house for Cassini support.
 <p></p>
   * **New or updated data user's guides**
 
-    * **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}**.
-    * **[ISS Data User's Guide]({{ site.holdings_url }}documents/COISS_0xxx/ISS-Users-Guide.pdf){:target="_blank"}** - updated in September 2018.
-    * **[RSS Data User Guide](/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** - released in September 2018.
-    * **[UVIS User's Guide]({{ site.holdings_url }}documents/COUVIS_8xxx/UVIS-Users-Guide.pdf){:target="_blank"}** - updated in July 2018.
+    * **[CIRS User Guide]({{ site.holdings_url }}documents/COCIRS_0xxx/CIRS-Users-Guide.pdf){:target="_blank"}** - Version 11.7, November 2014.
+    * **[ISS Data User's Guide]({{ site.holdings_url }}documents/COISS_0xxx/ISS-Users-Guide.pdf){:target="_blank"}** - Revised in September 2018.
+    * **[RSS Data User Guide](/cassini/rss/Cassini Radio Science Users Guide - 30 Sep 2018.pdf){:target="_blank"}** - Version 1.1, September 2018.
+    * **[UVIS User's Guide]({{ site.holdings_url }}documents/COUVIS_8xxx/UVIS-Users-Guide.pdf){:target="_blank"}** - Revised in July 2018.
 <p></p>
   * **Downloadable tables of enhanced geometric metadata**
 

--- a/website/cassini/iss/about.html
+++ b/website/cassini/iss/about.html
@@ -44,38 +44,34 @@ File names are in the form **Annnnnnnnnn_v.IMG**, where:
 
 ### 3\. Documentation
 
-The <a href="iss_data_user_guide_180916.pdf" target="_blank">**ISS Users Guide**</a>, in PDF format, was updated September 2018. It provides a substantial amount of information reguarding the instrument and its data in a single document. 
+The **[ISS Users Guide]({{ site.holdings_url }}documents/COISS_0xxx/ISS-Users-Guide.pdf){:target="_blank"}**, in PDF format, was updated September 2018. It provides a substantial amount of information reguarding the instrument and its data in a single document. 
 
-**Users are strongly encouraged to review an ISS <a href="aareadme.txt" target="_blank">aareadme.txt</a> file.** This file appears in the root directory of every volume. (Some of the header information in the aareadme.txt files varies from one volume to the next, but the body of information in the files is the same.) 
+**Users are strongly encouraged to review an ISS [aareadme.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0011/aareadme.txt){:target="_blank"} file.** This file appears in the root directory of every volume. (Some of the header information in the aareadme.txt files varies from one volume to the next, but the body of information in the files is the same.) 
 
 Further details of the ISS archive volumes can be found in the "Software
 Interface Specification" (SIS) Documents. These are found in the document
 directory on each data volume.
 
-  * The Data Product and Label SIS is available as <a href="edrsis.pdf" target="_blank">document/edrsis.pdf</a> and <a href="edrsis.txt" target="_blank">document/edrsis.txt</a>. 
+  * The Data Product and Label SIS is available as [document/edrsis.pdf]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/edrsis.pdf) and [document/edrsis.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/edrsis.txt){:target="_blank"}. 
+{:target="_blank"}
+  * The Volume Organization SIS is available as [document/archsis.pdf]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/archsis.pdf){:target="_blank"} and [document/archsis.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/archsis.txt){:target="_blank"}. 
 
-  * The Volume Organization SIS is available as <a href="archsis.pdf" target="_blank">document/archsis.pdf</a> and <a href="archsis.txt" target="_blank">document/archsis.txt</a>. 
+  * The image files are archived in VICAR2 format. Each data volume contains a file [COISS_xxxx/label/vicar2.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/label/vicar2.txt){:target="_blank"} providing the details of this file format. 
 
-  * The image files are archived in VICAR2 format. Each data volume contains a file <a href="vicar2.txt" target="_blank">COISS_xxxx/label/vicar2.txt</a> providing the details of this file format. 
-
-The [catalog](/link/volumes/COISS_2xxx/COISS_2001/catalog/) subdirectory on each volume
+The [catalog]({{ site.holdings_url }}volumes/COISS_2xxx/COISS_2001/catalog/){:target="_blank"} subdirectory on each volume
 contains a wealth of information about the ISS instrument, team and data set.
 See, in particular:
 
-  * <a href="JUPITERDS.txt" target="_blank">COISS_1xxx/catalog/jupiterds.cat</a>: Description of the Jupiter data set.
-<a href="SATURNDS.txt" target="_blank">COISS_2xxx/catalog/saturnds.cat</a>: Description of the Saturn
-data set.
+  * [COISS_1xxx/catalog/jupiterds.cat]({{ site.holdings_url }}volumes/COISS_1xxx/COISS_1001/catalog/jupiterds.cat){:target="_blank"}: Description of the Jupiter data set.
+  * [COISS_2xxx/catalog/saturnds.cat]({{ site.holdings_url }}volumes/COISS_2xxx/COISS_2001/catalog/saturnds.cat){:target="_blank"}: Description of the Saturndata set.
+  * [COISS_xxxx/catalog/issna_inst.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/issna_inst.cat){:target="_blank"}: Description of the narrow-angle camera.
+  * [COISS_xxxx/catalog/isswa_inst.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/isswa_inst.cat){:target="_blank"}: Description of the wide-angle camera.
+  * [COISS_xxxx/catalog/insthost.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/insthost.cat){:target="_blank"}: Description of the Cassini spacecraft.
+  * [COISS_xxxx/catalog/mission.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/mission.cat){:target="_blank"}: Description of the Cassini mission.
 
-  * <a href="ISSNA_INST.txt" target="_blank">COISS_xxxx/catalog/issna_inst.cat</a>: Description of the narrow-angle camera.
-  * <a href="ISSWA_INST.txt" target="_blank">COISS_xxxx/catalog/isswa_inst.cat</a>: Description of the wide-angle camera.
-  * <a href="INSTHOST.txt" target="_blank">COISS_xxxx/catalog/insthost.cat</a>: Description of the Cassini spacecraft.
-  * <a href="MISSION.txt" target="_blank">COISS_xxxx/catalog/mission.cat</a>: Description of the Cassini mission.
-
-A file, <a href="errata.txt" target="_blank">errata.txt</a>, in the root directory of each volume
+A file, [errata.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/errata.txt){:target="_blank"}, in the root directory of each volume
 documents any known anomalies or deviations from PDS standards, and identifies
 potential problems with the calibration files and their use.
 
-
-Additional descriptions of the instrument can be found at the <a href="//saturn.jpl.nasa.gov/imaging-science-subsystem/" target="_blank">Cassini ISS
-web page.</a>
+Additional descriptions of the instrument can be found at the [Cassini ISS web page.](//saturn.jpl.nasa.gov/imaging-science-subsystem/){:target="_blank"}
 

--- a/website/cassini/iss/about.html
+++ b/website/cassini/iss/about.html
@@ -52,9 +52,9 @@ Further details of the ISS archive volumes can be found in the "Software
 Interface Specification" (SIS) Documents. These are found in the document
 directory on each data volume.
 
-  * The Data Product and Label SIS is available as [document/edrsis.pdf]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/edrsis.pdf) and [document/edrsis.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/edrsis.txt){:target="_blank"}. 
+  * The Data Product and Label SIS is available as [documents/COISS_0xxx/Data-Product-SIS.pdf]({{ site.holdings_url }}documents/COISS_0xxx/Data-Product-SIS.pdf){:target="_blank"} and [documents/COISS_0xxx/Data-Product-SIS.txt]({{ site.holdings_url }}documents/COISS_0xxx/Data-Product-SIS.txt){:target="_blank"}. 
 {:target="_blank"}
-  * The Volume Organization SIS is available as [document/archsis.pdf]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/archsis.pdf){:target="_blank"} and [document/archsis.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/document/archsis.txt){:target="_blank"}. 
+  * The Volume Organization SIS is available as [documents/COISS_0xxx/Archive-SIS.pdf]({{ site.holdings_url }}documents/COISS_0xxx/Archive-SIS.pdf){:target="_blank"} and [documents/COISS_0xxx/Archive-SIS.txt]({{ site.holdings_url }}documents/COISS_0xxx/Archive-SIS.txt){:target="_blank"}. 
 
   * The image files are archived in VICAR2 format. Each data volume contains a file [COISS_xxxx/label/vicar2.txt]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/label/vicar2.txt){:target="_blank"} providing the details of this file format. 
 
@@ -63,7 +63,7 @@ contains a wealth of information about the ISS instrument, team and data set.
 See, in particular:
 
   * [COISS_1xxx/catalog/jupiterds.cat]({{ site.holdings_url }}volumes/COISS_1xxx/COISS_1001/catalog/jupiterds.cat){:target="_blank"}: Description of the Jupiter data set.
-  * [COISS_2xxx/catalog/saturnds.cat]({{ site.holdings_url }}volumes/COISS_2xxx/COISS_2001/catalog/saturnds.cat){:target="_blank"}: Description of the Saturndata set.
+  * [COISS_2xxx/catalog/saturnds.cat]({{ site.holdings_url }}volumes/COISS_2xxx/COISS_2001/catalog/saturnds.cat){:target="_blank"}: Description of the Saturn data set.
   * [COISS_xxxx/catalog/issna_inst.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/issna_inst.cat){:target="_blank"}: Description of the narrow-angle camera.
   * [COISS_xxxx/catalog/isswa_inst.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/isswa_inst.cat){:target="_blank"}: Description of the wide-angle camera.
   * [COISS_xxxx/catalog/insthost.cat]({{ site.holdings_url }}volumes/COISS_0xxx/COISS_0001/catalog/insthost.cat){:target="_blank"}: Description of the Cassini spacecraft.


### PR DESCRIPTION
This resolves the links on the Cassini ISS about page by updating to use the holdings folder.  This update includes changes for the asset updates as well as the broken links.  No asset files are removed w/this pull request.