### PR TITLE
Update links and add tar.gz file size

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -166,13 +166,19 @@ p.superwide > a > img {
 }
 
 .rss  {
-  max-height: 272px;
   max-width: 1124px;
 }
 
+.rss img {
+  max-height: 272px;
+}
+
 .ringocc {
-  max-height: 461px;
   max-width: 1209px;
+}
+
+.ringocc img {
+  max-height: 461px;
 }
 
 /* homepage boxes */

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -147,7 +147,7 @@ body {
     max-width: 60em;
   }
   .content li {
-    max-width: 50em;
+    max-width: 60em;
   }
 }
 .content p.superwide {

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -13,6 +13,7 @@
 /* some PDS-rings specific styles */
 .pds-container {
     overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 .nav-container {
@@ -156,8 +157,6 @@ body {
   overflow: visible;
 }
 
-
-
 /* .content container customizations for pages */
 p.superwide > a > img {
   overflow:visible;
@@ -166,7 +165,15 @@ p.superwide > a > img {
   width: 100%;
 }
 
+.rss  {
+  max-height: 272px;
+  max-width: 1124px;
+}
 
+.ringocc {
+  max-height: 461px;
+  max-width: 1209px;
+}
 
 /* homepage boxes */
 .homebox {

--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -5,7 +5,8 @@ title: "Spacecraft-Based Ring Occultations"
 ---
 
 {:class="superwide"}
-[![Radial Profile](//pds-rings.seti.org/ringocc/profile1.jpg)](//pds-rings.seti.org/ringocc/profile1.jpg){:class="img-responsive "}
+[![Radial Profile](//pds-rings.seti.org/ringocc/kao-plot.png)](//pds-rings.seti.org/ringocc/kao-plot.png){:class="img-responsive "}\
+
 
 # Spacecraft-Based Ring Occultations
 

--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -4,11 +4,8 @@ layout_style: wide
 title: "Spacecraft-Based Ring Occultations"
 ---
 
-<p class = "superwide">
-	<a href = "profile1.jpg">
-		<img src = "profile1.jpg" alt = "Radial Profile">
-	</a>
-</p>
+{:class="superwide"}
+[![Radial Profile](//pds-rings.seti.org/ringocc/profile1.jpg)](//pds-rings.seti.org/ringocc/profile1.jpg){:class="img-responsive "}
 
 # Spacecraft-Based Ring Occultations
 
@@ -16,14 +13,14 @@ title: "Spacecraft-Based Ring Occultations"
 
 All three Cassini Ring Occultation datasets have been updated to version 2. Here are the links:
 
-  * **RSS version 2** \- Browse the data set on-line [CORSS_8001](/link/volumes/CORSS_8xxx/CORSS_8001/){:target="_blank"}, or download the entire data set [CORSS_8001 tar.gz](/link/archives-volumes/CORSS_8xxx/CORSS_8001.tar.gz).
-  * **UVIS version 2** \- Browse the data set on-line [COUVIS_8001](/link/volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}, or download the entire data set [COUVIS_8001 tar.gz](/link/archives-volumes/COUVIS_8xxx/COUVIS_8001.tar.gz).
-  * **VIMS version 2** \- Browse the data set on-line [COVIMS_8001](/link/volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"}, or download the entire data set [COVIMS_8001 tar.gz](/link/archives-volumes/COVIMS_8xxx/COVIMS_8001.tar.gz).
+  * **RSS version 2** \- Browse the data set on-line [CORSS_8001]({{ site.viewmaster_url }}volumes/CORSS_8xxx/CORSS_8001/){:target="_blank"}, or download the entire data set [CORSS_8001 tar.gz](/link/archives-volumes/CORSS_8xxx/CORSS_8001.tar.gz) (6.14 GB).
+  * **UVIS version 2** \- Browse the data set on-line [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}, or download the entire data set [COUVIS_8001 tar.gz](/link/archives-volumes/COUVIS_8xxx/COUVIS_8001.tar.gz) (438 MB).
+  * **VIMS version 2** \- Browse the data set on-line [COVIMS_8001]({{ site.viewmaster_url }}volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"}, or download the entire data set [COVIMS_8001 tar.gz](/link/archives-volumes/COVIMS_8xxx/COVIMS_8001.tar.gz) (320 MB).
 
 Details about each of the instruments are available from our [Cassini information pages](/cassini/).
 
-**5/3/19 Versions 2 of the UVIS dataset [COUVIS_8001](/link/volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}
-	and the VIMS dataset [COVIMS_8001](/link/volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"} are available online.**
+**5/3/19 Versions 2 of the UVIS dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}
+	and the VIMS dataset [COVIMS_8001]({{ site.viewmaster_url }}volumes/COVIMS_8xxx/COVIMS_8001/){:target="_blank"} are available online.**
 
   * **UVIS Version 2 includes:**
 
@@ -53,7 +50,7 @@ Details about each of the instruments are available from our [Cassini informatio
     * Details of the data processing involved in the production of this data set are provided in
       VIMS-occultation-processing.txt in the document directory, and in NICHOLSONETAL2019.
 
-**1/17/19 Version 2 of the RSS dataset [CORSS_8001](/link/volumes/CORSS_8xxx/CORSS_8001/){:target="_blank"} is available online.**
+**1/17/19 Version 2 of the RSS dataset [CORSS_8001]({{ site.viewmaster_url }}volumes/CORSS_8xxx/CORSS_8001/){:target="_blank"} is available online.**
 
   * **RSS Version 2 includes:**
     * reprocessed versions of the material contained in the earlier version,
@@ -71,11 +68,11 @@ should exercise caution when using the Voyager RSS occultation data.**
 In addition, we have a small data set of Saturn ring radial profiles,
 generated from the finest resolution Voyager ISS images.
 
-  * **PPS** \- Browse the data set on-line [VG_2801](/link/volumes/VG_28xx/VG_2801/){:target="_blank"}, or download the entire data set [VG_2801 tar.gz](/link/archives-volumes/VG_28xx/VG_2801.tar.gz).
-  * **UVS** \- Browse the data set on-line [VG_2802](/link/volumes/VG_28xx/VG_2802/){:target="_blank"}, or download the entire data set [VG_2802 tar.gz](/link/archives-volumes/VG_28xx/VG_2802.tar.gz).
-  * **ISS** \- Browse the data set on-line [VG_2810](/link/volumes/VG_28xx/VG_2810/){:target="_blank"}, or download the entire data set [VG_2810 tar.gz](/link/archives-volumes/VG_28xx/VG_2810.tar.gz).
-  * **RSS** \- Browse the data set on-line [VG_2803](/link/volumes/VG_28xx_peer_review/VG_2803/){:target="_blank"},
-  or download the entire data set [VG_2803 tar.gz](/link/archives-volumes/VG_28xx_peer_review/VG_2803.tar.gz).
+  * **PPS** \- Browse the data set on-line [VG_2801]({{ site.viewmaster_url }}volumes/VG_28xx/VG_2801/){:target="_blank"}, or download the entire data set [VG_2801 tar.gz](/link/archives-volumes/VG_28xx/VG_2801.tar.gz) (75 MB).
+  * **UVS** \- Browse the data set on-line [VG_2802]({{ site.viewmaster_url }}volumes/VG_28xx/VG_2802/){:target="_blank"}, or download the entire data set [VG_2802 tar.gz](/link/archives-volumes/VG_28xx/VG_2802.tar.gz) (144 MB).
+  * **ISS** \- Browse the data set on-line [VG_2810]({{ site.viewmaster_url }}volumes/VG_28xx/VG_2810/){:target="_blank"}, or download the entire data set [VG_2810 tar.gz](/link/archives-volumes/VG_28xx/VG_2810.tar.gz) (187 MB).
+  * **RSS** \- Browse the data set on-line [VG_2803]({{ site.viewmaster_url }}volumes/VG_28xx_peer_review/VG_2803/){:target="_blank"},
+  or download the entire data set [VG_2803 tar.gz]({{ site.holdings_url }}archives-volumes/VG_28xx_peer_review/VG_2803.tar.gz) (363 MB).
   The original raw data files for the Voyager 1 RSS Saturn ring system occultation data set, VG1 at Saturn:
   VG1-S-RSS-1-ROCC-V1.0, can be accessed from the [Voyager RSS web page at the PPI Node](//pds-ppi.igpp.ucla.edu/mission/Voyager_1/VG1/RSS){:target="_blank"}.
   PDS currently does not have a copy of the original raw data files for the Voyager 2 RSS Uranus ring system occultation.
@@ -99,7 +96,7 @@ Users are strongly encouraged to review the
 which includes a comprehensive Users Guide as well as models of the individual
 Uranian rings.
 
-To download the entire set in a single TAR.GZ file, [click here](https://pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased){:target="_blank"}.
+To download the entire set in a single TAR.GZ file, [click here](//pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased){:target="_blank"}.
 
 
 ## Saturn Rings
@@ -112,7 +109,7 @@ telescope, the European Southern Observatory's 2.2 meter telescope, the IRTF,
 the Lick 1 meter telescope, the McDonald 2.7 meter telescope, and the Palomar
 200 inch telescope.
 
-  * Browse the data sets on-line [EBROCC_0001](/link/volumes/EBROCC_xxxx/EBROCC_0001/){:target="_blank"}, or download the entire six data set volume [EBROCC_0001 tar.gz](/link/archives-volumes/EBROCC_xxxx/EBROCC_0001.tar.gz).
+  * Browse the data sets on-line [EBROCC_0001]({{ site.viewmaster_url }}volumes/EBROCC_xxxx/EBROCC_0001/){:target="_blank"}, or download the entire six data set volume [EBROCC_0001 tar.gz](/link/archives-volumes/EBROCC_xxxx/EBROCC_0001.tar.gz) (5.14 MB).
 
 
 For more information about the 28 Sgr occultation, see:

--- a/website/ringocc/index.html
+++ b/website/ringocc/index.html
@@ -97,7 +97,7 @@ Users are strongly encouraged to review the
 which includes a comprehensive Users Guide as well as models of the individual
 Uranian rings.
 
-To download the entire set in a single TAR.GZ file, [click here](//pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased){:target="_blank"}.
+To download the entire set in a single TAR.GZ file, [click here](//pds-rings.seti.org/pds4/archives-bundles/uranus_occs_earthbased){:target="_blank"} (6.0 GB).
 
 
 ## Saturn Rings


### PR DESCRIPTION
fixes #141
-Updated the links; note - only asset in this folder is profile1.jpg.
-Added file sizes to the tar.gz download text
-Changed the max-width of li element to 60em to account for slightly longer text.