### PR TITLE
Updated links in HST

### DIFF
--- a/website/hst/data.html
+++ b/website/hst/data.html
@@ -1,7 +1,0 @@
----
-layout: base
-layout_style: default
----
-
-
-

--- a/website/hst/index.html
+++ b/website/hst/index.html
@@ -1,5 +1,7 @@
 ---
 layout: base
+layout_style: default
+title: "HST Data"
 ---
 
 # HST Data at the PDS Ring-Moon Systems Node
@@ -17,9 +19,8 @@ HST.
 
 HST provides some of our finest Earth-based data on the outer planets.
 Literally hundreds of planetary programs have been carried out using HST. All
-HST products can be found in the Multimission Archive at STScI,
-[MAST](//archive.stsci.edu/index.html){:target="_blank"}, and can be calibrated on-the-fly
-prior to retrieval using the most current calibration files and algorithims.
+HST products can be found in the [Multimission Archive at STScI MAST](//archive.stsci.edu/index.html){:target="_blank"}, 
+and can be calibrated on-the-fly prior to retrieval using the most current calibration files and algorithims.
 
 Although the files are reliably archived, the STScI search interface is not
 well adapted to planetary queries. In order to incorporate this rich data
@@ -59,15 +60,15 @@ letter identifiers for the instruments as STScI, "I" = WFC3; "J" = ACS; "U" =
 "WFPC2", "O" = STIS, "N" = NICMOS. These are available for directory tree browsing, or for downloading
 as separate [tar.gz](/help/targz.html) files for each "data set".
 
-  * ACS -   [Browsable Volumes](/link/volumes/HSTJx_xxxx/),    [downloadable tar.gz files](/link/archives-volumes/HSTJx_xxxx/)
+  * ACS -   [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTJx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTJx_xxxx/){:target="_blank"}
 
-  * NICMOS -  [Browsable Volumes](/link/volumes/HSTNx_xxxx/),    [downloadable tar.gz files](/link/archives-volumes/HSTNx_xxxx/)
+  * NICMOS -  [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTNx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTNx_xxxx/){:target="_blank"}
 
-  * STIS - [Browsable Volumes](/link/volumes/HSTOx_xxxx/),    [downloadable tar.gz files](/link/archives-volumes/HSTOx_xxxx/)
+  * STIS - [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTOx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTOx_xxxx/){:target="_blank"}
 
-  * WFPC2 - [Browsable Volumes](/link/volumes/HSTUx_xxxx/),    [downloadable tar.gz files](/link/archives-volumes/HSTUx_xxxx/)
+  * WFPC2 - [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTUx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTUx_xxxx/){:target="_blank"}
 
-  * WFC3 -  [Browsable Volumes](/link/volumes/HSTIx_xxxx/),    [downloadable tar.gz files](/link/archives-volumes/HSTIx_xxxx/)
+  * WFC3 -  [Browsable Volumes]({{ site.viewmaster_url }}volumes/HSTIx_xxxx/){:target="_blank"},    [downloadable tar.gz files]({{ site.viewmaster_url }}archives-volumes/HSTIx_xxxx/){:target="_blank"}
 
 ### Small Satellite Astrometry
 

--- a/website/hst/index.html
+++ b/website/hst/index.html
@@ -19,7 +19,7 @@ HST.
 
 HST provides some of our finest Earth-based data on the outer planets.
 Literally hundreds of planetary programs have been carried out using HST. All
-HST products can be found in the [Multimission Archive at STScI MAST](//archive.stsci.edu/index.html){:target="_blank"}, 
+HST products can be found in **[MAST](//archive.stsci.edu/index.html){:target="_blank"}**, the multi-mission archive at STSCI,
 and can be calibrated on-the-fly prior to retrieval using the most current calibration files and algorithims.
 
 Although the files are reliably archived, the STScI search interface is not

--- a/website/hst/stsci.html
+++ b/website/hst/stsci.html
@@ -1,7 +1,0 @@
----
-layout: base
-layout_style: default
----
-
-
-


### PR DESCRIPTION
-Minor updates to links; no assets in HST
-Minor update to the header to standardize.
-Deleted unused files.
Note that tar.gz links are to folders to many files, so no file sizes were added to the text as they are not direct-to-download links.
fixes #135