### PR TITLE
Add variable to use in markdown for asset location

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -10,6 +10,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 opus_url: "//opus.pds-rings.seti.org/opus/#"
 holdings_url: "//pds-rings.seti.org/holdings/"
 viewmaster_url: "//pds-rings.seti.org/viewmaster/"
+assets_url: "//pds-rings.seti.org/"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
As part of #110, added a variable to utilize in the markdown so that website assets can be later redirected to a different folder as they are separated out.  Example usage:

 ![\[RING PSEUDO-IMAGE\]]({{ site.assets_url }}cassini/uvis/PIA05075.jpg)