### PR TITLE
127 update links cassini uvis

### DIFF
--- a/website/_data/tables/cassini_uvis_access.yaml
+++ b/website/_data/tables/cassini_uvis_access.yaml
@@ -18,16 +18,19 @@
 
         - table_row: 
             id: COUVIS_0001 
+            file_size: 452 MB
             clock_range: 1294420183 to 1356956400 
             date_range: 1999-01-07 to 2000-12-31  
 
         - table_row: 
-            id: COUVIS_0002 
+            id: COUVIS_0002
+            file_size: 361 MB
             clock_range: 1357007021 to 1364774880 
             date_range: 2001-01-01 to 2001-04-01  
 
         - table_row: 
             id: COUVIS_0003 
+            file_size: 358 MB
             clock_range: 1364775615 to 1392458352 
             date_range: 2001-04-01 to 2002-02-15  
 
@@ -39,26 +42,31 @@
 
         - table_row: 
             id: COUVIS_0004 
+            file_size: 388 MB
             clock_range: 1392337464 to 1420052434 
             date_range: 2002-02-14 to 2003-01-01  
 
         - table_row: 
-            id: COUVIS_0005 
+            id: COUVIS_0005
+            file_size: 361 MB 
             clock_range: 142010 Release4057 to 1450974152 
             date_range: 2003-01-01 to 2003-12-25  
 
         - table_row: 
             id: COUVIS_0006 
+            file_size: 1.6 GB
             clock_range: 1450938117 to 1463592274 
             date_range: 2003-12-24 to 2004-05-19  
 
         - table_row: 
             id: COUVIS_0007 
+            file_size: 628 MB
             clock_range: 1463624099 to 1466514410 
             date_range: 2004-05-19 to 2004-06-21  
 
         - table_row: 
-            id: COUVIS_0008 
+            id: COUVIS_0008
+            file_size: 595 MB 
             clock_range: 1467343910 to 1475280248 
             date_range: 2004-07-01 to 2004-10-01  
 
@@ -69,6 +77,7 @@
 
         - table_row: 
             id: COUVIS_0009 
+            file_size: 299 MB
             clock_range: 14752010 Release91 to 1483226339 
             date_range: 2004-09-30 to 2005-01-01  
 
@@ -78,7 +87,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0010 
+            id: COUVIS_0010
+            file_size: 263 MB 
             clock_range: 1483223180 to 1490959294 
             date_range: 2005-12-31 to 2005-03-31  
 
@@ -89,6 +99,7 @@
 
         - table_row: 
             id: COUVIS_0011 
+            file_size: 308 MB
             clock_range: 1491022376 to 1498835186 
             date_range: 2005-04-01 to 2005-07-01  
 
@@ -99,6 +110,7 @@
 
         - table_row: 
             id: COUVIS_0012 
+            file_size: 340 MB
             clock_range: 1498835186 to 1506847245 
             date_range: 2005-06-30 to 2005-10-01  
 
@@ -109,6 +121,7 @@
 
         - table_row: 
             id: COUVIS_0013 
+            file_size: 254 MB
             clock_range: 1506689171 to 1514703243 
             date_range: 2005-10-01 to 2005-12-31  
 
@@ -119,6 +132,7 @@
 
         - table_row: 
             id: COUVIS_0014 
+            file_size: 352 MB
             clock_range: 1514781983 to 1522540571 
             date_range: 2006-01-01 to 2006-03-31  
 
@@ -129,6 +143,7 @@
 
         - table_row: 
             id: COUVIS_0015 
+            file_size: 226 MB
             clock_range: 1522544806 to 1530386267 
             date_range: 2006-04-01 to 2006-07-01  
 
@@ -138,7 +153,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0016 
+            id: COUVIS_0016
+            file_size: 336 MB 
             clock_range: 1530435183 to 1538305897 
             date_range: 2006-07-01 to 2006-09-30  
 
@@ -148,7 +164,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0017 
+            id: COUVIS_0017
+            file_size: 522 MB 
             clock_range: 1538365194 to 1546290674 
             date_range: 2006-10-01 to 2006-12-31  
 
@@ -159,6 +176,7 @@
 
         - table_row: 
             id: COUVIS_0018 
+            file_size: 622 MB
             clock_range: 1546310745 to 1554074554 
             date_range: 2007-01-01 to 2007-03-31  
 
@@ -169,6 +187,7 @@
 
         - table_row: 
             id: COUVIS_0019 
+            file_size: 521 MB
             clock_range: 1554074627 to 1561922823 
             date_range: 2007-03-31 to 2007-07-01  
 
@@ -179,6 +198,7 @@
 
         - table_row: 
             id: COUVIS_0020 
+            file_size: 509 MB
             clock_range: 1561952973 to 1569879943 
             date_range: 2007-07-01 to 2007-09-30  
 
@@ -189,6 +209,7 @@
 
         - table_row: 
             id: COUVIS_0021 
+            file_size: 361 MB
             clock_range: 1570149867 to 1577779343 
             date_range: 2007-10-03 to 2007-12-31  
 
@@ -199,6 +220,7 @@
 
         - table_row: 
             id: COUVIS_0022 
+            file_size: 458 MB
             clock_range: 1577860749 to 1585697418 
             date_range: 2008-01-01 to 2008-04-01  
 
@@ -209,6 +231,7 @@
 
         - table_row: 
             id: COUVIS_0023 
+            file_size: 379 MB
             clock_range: 1585736813 to 1593368263 
             date_range: 2008-04-01 to 2008-06-29  
 
@@ -219,6 +242,7 @@
 
         - table_row: 
             id: COUVIS_0024 
+            file_size: 518 MB
             clock_range: 1593564831 to 1601481892 
             date_range: 2008-07-01 to 2008-09-30  
 
@@ -228,7 +252,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0025 
+            id: COUVIS_0025
+            file_size: 588 MB 
             clock_range: 1601567205 to 1609435849 
             date_range: 2008-10-01 to 2008-12-31  
 
@@ -239,6 +264,7 @@
 
         - table_row: 
             id: COUVIS_0026 
+            file_size: 581 MB
             clock_range: 1609572386 to 1617176831 
             date_range: 2009-01-02 to 2009-03-31  
 
@@ -249,6 +275,7 @@
 
         - table_row: 
             id: COUVIS_0027 
+            file_size: 1.07 GB
             clock_range: 1617239749 to 1625080037 
             date_range: 2009-04-01 to 2009-07-01  
 
@@ -259,6 +286,7 @@
 
         - table_row: 
             id: COUVIS_0028 
+            file_size: 528 MB
             clock_range: 1625117322 to 1633044544 
             date_range: 2009-07-01 to 2009-10-01  
 
@@ -268,7 +296,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0029 
+            id: COUVIS_0029
+            file_size: 1.09 GB 
             clock_range: 1633050431 to 1640947593 
             date_range: 2009-10-01 to 2009-12-31  
 
@@ -279,6 +308,7 @@
 
         - table_row: 
             id: COUVIS_0030 
+            file_size: 1.82 GB
             clock_range: 1641073059 to 1648666204 
             date_range: 2010-01-01 to 2010-03-31  
 
@@ -289,6 +319,7 @@
 
         - table_row: 
             id: COUVIS_0031 
+            file_size: 316 MB
             clock_range: 1648802013 Release to 1656556018 
             date_range: 2010-04-01 to 2010-06-30  
 
@@ -298,7 +329,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0032 
+            id: COUVIS_0032
+            file_size: 343 MB 
             clock_range: 1656936571 to 1664492775 
             date_range: 2010-07-04 to 2010-09-30  
 
@@ -309,6 +341,7 @@
 
         - table_row: 
             id: COUVIS_0033 
+            file_size: 935 MB
             clock_range: 1664806708 to 1672459209 
             date_range: 2010-10-03 to 2010-12-31  
 
@@ -319,6 +352,7 @@
 
         - table_row: 
             id: COUVIS_0034 
+            file_size: 338 MB
             clock_range: 1672536439 to 1680307270 
             date_range: 2011-01-01 to 2011-04-01  
 
@@ -329,6 +363,7 @@
 
         - table_row: 
             id: COUVIS_0035 
+            file_size: 804 MB
             clock_range: 1680427269 to 1688016768 
             date_range: 2011-04-02 to 2011-06-29  
 
@@ -338,7 +373,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0036 
+            id: COUVIS_0036
+            file_size: 732 MB 
             clock_range: 1692103081 to 1696094678 
             date_range: 2011-08-15 to 2011-09-30  
 
@@ -348,7 +384,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0037 
+            id: COUVIS_0037
+            file_size: 379 MB 
             clock_range: 1696121672 to 1704055620 
             date_range: 2011-10-01 to 2011-12-31  
 
@@ -358,7 +395,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0038 
+            id: COUVIS_0038
+            file_size: 622 MB 
             clock_range: 1704078010 to 1711916700 
             date_range: 2012-01-01 to 2012-04-01  
 
@@ -368,7 +406,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0039 
+            id: COUVIS_0039
+            file_size: 315 MB 
             clock_range: 1712030009 to 1719783289 
             date_range: 2012-04-02 to 2012-07-01  
 
@@ -379,6 +418,7 @@
 
         - table_row: 
             id: COUVIS_0040 
+            file_size: 808 MB
             clock_range: 1719818180 to 1727742422 
             date_range: 2012-07-01 to 2012-10-01  
 
@@ -388,7 +428,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0041 
+            id: COUVIS_0041
+            file_size: 269 MB 
             clock_range: 1727856550 to 1735622211 
             date_range: 2012-10-02 to 2012-12-31  
 
@@ -399,6 +440,7 @@
 
         - table_row: 
             id: COUVIS_0042 
+            file_size: 262 MB
             clock_range: 1735786741 to 1743397041 
             date_range: 2013-01-02 to 2013-03-31  
 
@@ -409,6 +451,7 @@
 
         - table_row: 
             id: COUVIS_0043 
+            file_size: 451 MB
             clock_range: 1743475671 to 1751270765 
             date_range: 2013-04-01 to 2013-06-30  
 
@@ -419,6 +462,7 @@
 
         - table_row: 
             id: COUVIS_0044 
+            file_size: 1.3 GB
             clock_range: 1751345559 to 1759273132 
             date_range: 2013-07-01 to 2013-09-30  
 
@@ -429,6 +473,7 @@
 
         - table_row: 
             id: COUVIS_0045 
+            file_size: 664 MB
             clock_range: 1759280403 to 1767211390 
             date_range: 2013-10-01 to 2014-01-01  
 
@@ -439,6 +484,7 @@
 
         - table_row: 
             id: COUVIS_0046 
+            file_size: 278 MB
             clock_range: 1767265209 to 1775004450 
             date_range: 2014-01-01 to 2014-03-31  
 
@@ -448,7 +494,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0047 
+            id: COUVIS_0047
+            file_size: 699 MB 
             clock_range: 1775005271 to 1782861212 
             date_range: 2014-04-01 to 2014-07-01  
 
@@ -459,6 +506,7 @@
 
         - table_row: 
             id: COUVIS_0048 
+            file_size: 1.34 GB
             clock_range: 1782868936 to 1790797721 
             date_range: 2014-07-01 to 2014-10-01  
 
@@ -469,6 +517,7 @@
 
         - table_row: 
             id: COUVIS_0049 
+            file_size: 339 MB
             clock_range: 1790898351 to 1798741092 
             date_range: 2014-10-01 to 2015-01-01
 
@@ -479,6 +528,7 @@
 
         - table_row: 
             id: COUVIS_0050 
+            file_size: 434 MB
             clock_range: 1798829803 to 1806533009 
             date_range: 2015-01-01 to 2015-03-31
 
@@ -488,7 +538,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0051 
+            id: COUVIS_0051
+            file_size: 636 MB 
             clock_range: 1806541807 to 1814401072 
             date_range: 2015-04-01 to 2015-06-30
 
@@ -499,6 +550,7 @@
 
         - table_row: 
             id: COUVIS_0052 
+            file_size: 1.09 GB
             clock_range: 1814509882 to 1822351553 
             date_range: 2015-07-02 to 2015-10-01
 
@@ -509,6 +561,7 @@
 
         - table_row: 
             id: COUVIS_0053 
+            file_size: 948 MB
             clock_range: 1822366078 to 1830279934 
             date_range: 2015-10-01 to 2016-01-01
 
@@ -519,6 +572,7 @@
 
         - table_row: 
             id: COUVIS_0054 
+            file_size: 439 MB
             clock_range: 1830306971 to 1838163650 
             date_range: 2016-01-01 to 2016-04-01
 
@@ -529,6 +583,7 @@
 
         - table_row: 
             id: COUVIS_0055 
+            file_size: 416 MB
             clock_range: 1838164487 to 1846016348 
             date_range: 2016-04-02 to 2016-07-02
 
@@ -538,7 +593,8 @@
     section_rows: 
 
         - table_row: 
-            id: COUVIS_0056 
+            id: COUVIS_0056
+            file_size: 1.95 GB
             clock_range: 1846029873 to 1853974816 
             date_range: 2016-07-01 to 2016-09-30
 
@@ -549,6 +605,7 @@
 
         - table_row: 
             id: COUVIS_0057 
+            file_size: 711 MB
             clock_range: 1853975456 to 1861772866 
             date_range: 2016-10-01 to 2016-12-30
 
@@ -559,6 +616,7 @@
 
         - table_row: 
             id: COUVIS_0058 
+            file_size: 746 MB
             clock_range: 1861943868 to 1869672278 
             date_range: 2017-01-01 to 2017-03-31
 
@@ -569,6 +627,7 @@
 
         - table_row: 
             id: COUVIS_0059 
+            file_size: 753 MB
             clock_range: 1869748418 to 1877557568 
             date_range: 2017-04-01 to 2017-06-30
 
@@ -579,5 +638,6 @@
 
         - table_row: 
             id: COUVIS_0060 
+            file_size: 713 MB
             clock_range: 1877617293 to 1884137111 
             date_range: 2017-07-01 to 2017-09-15

--- a/website/_includes/data_table.html
+++ b/website/_includes/data_table.html
@@ -183,13 +183,15 @@
                 {% else %}
 
                   {% if col contains "Bundled Volumes" %}
-                    <a href = "{{ site.holdings_url }}archives-volumes/{{ base_dir }}/{{ row.table_row.id }}.tar.gz">
+                    <a href = "{{ site.holdings_url }}archives-volumes/{{ base_dir }}/{{ row.table_row.id }}.tar.gz" 
+                        {% if row.table_row.file_size  %} title="({{ row.table_row.file_size }})" {% endif %}>
                         {{ row.table_row.id }}.tar.gz
                     </a>
                   {% endif %}
 
                   {% if col contains "Bundled Calibrated" %}
-                    <a href = "{{ site.holdings_url }}archives-calibrated/{{ base_dir }}/{{ row.table_row.id }}_calibrated.tar.gz">
+                    <a href = "{{ site.holdings_url }}archives-calibrated/{{ base_dir }}/{{ row.table_row.id }}_calibrated.tar.gz"
+                        {% if row.table_row.calib_file_size  %} title="({{ row.table_row.calib_file_size }})" {% endif %}>
                         {{ row.table_row.id }}_calibrated.tar.gz
                     </a>
                   {% endif %}

--- a/website/cassini/uvis/about.html
+++ b/website/cassini/uvis/about.html
@@ -45,37 +45,36 @@ On each volume, data are in subdirectories of the DATA directory.
 
 **Cassini UVIS Data Users Guide**
 
-  * **July 2018.** An updated version of the **<a href="1-UVIS_Users_Guide_-2018-Jan 15-For PDS-REV-2018-07-06.pdf" target="_blank">UVIS User Guide</a>** is available. 
+  * **July 2018.** An updated version of the **[UVIS User Guide]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Users-Guide.pdf){:target="_blank"}** is available. 
 
-** Users are strongly encouraged to review a UVIS <a href="AAREADME.TXT" target="_blank">AAREADME.TXT</a> file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
+** Users are strongly encouraged to review a UVIS [volumes/COUVIS_0xxx/COUVIS_00xx/AAREADME.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/AAREADME.TXT){:target="_blank"} file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
 
 Further details of the UVIS archive volumes can be found in the "Software
-Interface Specification" (SIS) Document. This is a file <a href="UVIS.TXT" target="_blank">UVIS.TXT</a>,
+Interface Specification" (SIS) Document. This is a file [volumes/COUVIS_0xxx/COUVIS_00xx/DOCUMENT/UVIS.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/DOCUMENT/UVIS.TXT){:target="_blank"},
 found in the DOCUMENT directory on each volume.
 
-The [CATALOG](/link/volumes/COUVIS_0xxx/COUVIS_0004/CATALOG/) subdirectory on each volume
+The [CATALOG]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0004/CATALOG/) subdirectory on each volume
 contains a wealth of information about the UVIS instrument, team and data
 sets. See, in particular:
 
-  * <a href="UVISINST.txt" target="_blank">COUVIS_xxxx/CATALOG/UVISINST.CAT</a>: Description of the UVIS instrument.
-  * <a href="INSTHOST.txt" target="_blank">COUVIS_xxxx/CATALOG/INSTHOST.CAT</a>: Description of the Cassini spacecraft.
-  * <a href="MISSION.txt" target="_blank">COUVIS_xxxx/CATALOG/MISSION.CAT</a>: Description of the Cassini mission.
+  * [COUVIS_xxxx/CATALOG/UVISINST.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/UVISINST.CAT){:target="_blank"}: Description of the UVIS instrument.
+  * [COUVIS_xxxx/CATALOG/INSTHOST.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/INSTHOST.CAT){:target="_blank"}: Description of the Cassini spacecraft.
+  * [COUVIS_xxxx/CATALOG/MISSION.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/MISSION.CAT){:target="_blank"}: Description of the Cassini mission.
 
 Representative data set information (there are variations in the header
 information for the corresponding catalog files associated with each phase,
 but the contents are the same):
 
-  * <a href="XCALDS.txt" target="_blank">COUVIS_xxxx/CATALOG/XCALDS.CAT</a>: Description of the UVIS calibration data set.
-  * <a href="XCUBEDS.txt" target="_blank">COUVIS_xxxx/CATALOG/XCUBEDS.CAT</a>: Description of the UVIS cube data set.
-  * <a href="XSPECDS.txt" target="_blank">COUVIS_xxxx/CATALOG/XSPECDS.CAT</a>: Description of the UVIS spectrum data set.
-  * <a href="XSSBDS.txt" target="_blank">COUVIS_xxxx/CATALOG/XSSBDS.CAT</a>: Description of the UVIS solar stellar brightness data set.
-  * <a href="XWAVDS.txt" target="_blank">COUVIS_xxxx/CATALOG/XWAVDS.CAT</a>: Description of the UVIS image at one wavelength data set.
+  * [COUVIS_xxxx/CATALOG/SCALDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SCALDS.CAT){:target="_blank"}: Description of the UVIS calibration data set.
+  * [COUVIS_xxxx/CATALOG/SCUBEDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SCUBEDS.CAT){:target="_blank"}: Description of the UVIS cube data set.
+  * [COUVIS_xxxx/CATALOG/SSPECDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SSPECDS.CAT){:target="_blank"}: Description of the UVIS spectrum data set.
+  * [COUVIS_xxxx/CATALOG/SSSBDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SSSBDS.CAT){:target="_blank"}: Description of the UVIS solar stellar brightness data set.
+  * [COUVIS_xxxx/CATALOG/SWAVDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SWAVDS.CAT){:target="_blank"}: Description of the UVIS image at one wavelength data set.
 
-A file, <a href="ERRATA.TXT" target="_blank">ERRATA.TXT</a>, in the root directory of each volume
+A file, [ERRATA.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/ERRATA.TXT){:target="_blank"}, in the root directory of each volume
 documents any known anomalies or deviations from PDS standards contained in
 that volume.
 
 
-Additional descriptions of the instrument can be found at the <a href="https://saturn.jpl.nasa.gov/ultraviolet-imaging-spectrograph/" target="_blank">Cassini UVIS
-web page.</a>
+Additional descriptions of the instrument can be found at the [Cassini UVIS web page.](//saturn.jpl.nasa.gov/ultraviolet-imaging-spectrograph/){:target="_blank"}
 

--- a/website/cassini/uvis/about.html
+++ b/website/cassini/uvis/about.html
@@ -47,7 +47,7 @@ On each volume, data are in subdirectories of the DATA directory.
 
   * **July 2018.** An updated version of the **[UVIS User Guide]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Users-Guide.pdf){:target="_blank"}** is available. 
 
-** Users are strongly encouraged to review a UVIS [AAREADME.TXT]({{ site.holdings_url }}/metadata/COUVIS_0xxx/AAREADME.txt){:target="_blank"} file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
+** Users are strongly encouraged to review a UVIS [AAREADME.TXT]({{ site.holdings_url }}metadata/COUVIS_0xxx/AAREADME.txt){:target="_blank"} file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
 
 Further details of the UVIS archive volumes can be found in the "Software
 Interface Specification" (SIS) Document. This is a file [UVIS-Archive-SIS.pdf]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Archive-SIS.pdf){:target="_blank"},

--- a/website/cassini/uvis/about.html
+++ b/website/cassini/uvis/about.html
@@ -70,8 +70,8 @@ but the contents are the same):
   * COUVIS_xxxx/CATALOG/SSSBDS.CAT: Description of the UVIS solar stellar brightness data set.
   * COUVIS_xxxx/CATALOG/SWAVDS.CAT: Description of the UVIS image at one wavelength data set.
 
-A file, [ERRATA.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/ERRATA.TXT){:target="_blank"}, in the root directory of each volume
-documents any known anomalies or deviations from PDS standards contained in
+The file, COUVIS_0xxx/COUVIS_006xx/ERRATA.TXT, is in the root directory of each volume
+and documents any known anomalies or deviations from PDS standards contained in
 that volume.
 
 

--- a/website/cassini/uvis/about.html
+++ b/website/cassini/uvis/about.html
@@ -47,29 +47,28 @@ On each volume, data are in subdirectories of the DATA directory.
 
   * **July 2018.** An updated version of the **[UVIS User Guide]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Users-Guide.pdf){:target="_blank"}** is available. 
 
-** Users are strongly encouraged to review a UVIS [volumes/COUVIS_0xxx/COUVIS_00xx/AAREADME.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/AAREADME.TXT){:target="_blank"} file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
+** Users are strongly encouraged to review a UVIS [AAREADME.TXT]({{ site.holdings_url }}/metadata/COUVIS_0xxx/AAREADME.txt){:target="_blank"} file. ** This file appears in the root directory of every volume. (Some of the header information in the AAREADME.TXT files varies from one volume to the next, but the body of information in the files is the same.) 
 
 Further details of the UVIS archive volumes can be found in the "Software
-Interface Specification" (SIS) Document. This is a file [volumes/COUVIS_0xxx/COUVIS_00xx/DOCUMENT/UVIS.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/DOCUMENT/UVIS.TXT){:target="_blank"},
+Interface Specification" (SIS) Document. This is a file [UVIS-Archive-SIS.pdf]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Archive-SIS.pdf){:target="_blank"},
 found in the DOCUMENT directory on each volume.
 
-The [CATALOG]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0004/CATALOG/) subdirectory on each volume
-contains a wealth of information about the UVIS instrument, team and data
+The CATALOG subdirectory on each volume contains a wealth of information about the UVIS instrument, team and data
 sets. See, in particular:
 
-  * [COUVIS_xxxx/CATALOG/UVISINST.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/UVISINST.CAT){:target="_blank"}: Description of the UVIS instrument.
-  * [COUVIS_xxxx/CATALOG/INSTHOST.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/INSTHOST.CAT){:target="_blank"}: Description of the Cassini spacecraft.
-  * [COUVIS_xxxx/CATALOG/MISSION.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/MISSION.CAT){:target="_blank"}: Description of the Cassini mission.
+  * COUVIS_xxxx/CATALOG/UVISINST.CAT: Description of the UVIS instrument.
+  * COUVIS_xxxx/CATALOG/INSTHOST.CAT: Description of the Cassini spacecraft.
+  * COUVIS_xxxx/CATALOG/MISSION.CAT: Description of the Cassini mission.
 
 Representative data set information (there are variations in the header
 information for the corresponding catalog files associated with each phase,
 but the contents are the same):
 
-  * [COUVIS_xxxx/CATALOG/SCALDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SCALDS.CAT){:target="_blank"}: Description of the UVIS calibration data set.
-  * [COUVIS_xxxx/CATALOG/SCUBEDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SCUBEDS.CAT){:target="_blank"}: Description of the UVIS cube data set.
-  * [COUVIS_xxxx/CATALOG/SSPECDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SSPECDS.CAT){:target="_blank"}: Description of the UVIS spectrum data set.
-  * [COUVIS_xxxx/CATALOG/SSSBDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SSSBDS.CAT){:target="_blank"}: Description of the UVIS solar stellar brightness data set.
-  * [COUVIS_xxxx/CATALOG/SWAVDS.CAT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/CATALOG/SWAVDS.CAT){:target="_blank"}: Description of the UVIS image at one wavelength data set.
+  * COUVIS_xxxx/CATALOG/SCALDS.CAT: Description of the UVIS calibration data set.
+  * COUVIS_xxxx/CATALOG/SCUBEDS.CAT: Description of the UVIS cube data set.
+  * COUVIS_xxxx/CATALOG/SSPECDS.CAT: Description of the UVIS spectrum data set.
+  * COUVIS_xxxx/CATALOG/SSSBDS.CAT: Description of the UVIS solar stellar brightness data set.
+  * COUVIS_xxxx/CATALOG/SWAVDS.CAT: Description of the UVIS image at one wavelength data set.
 
 A file, [ERRATA.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/ERRATA.TXT){:target="_blank"}, in the root directory of each volume
 documents any known anomalies or deviations from PDS standards contained in

--- a/website/cassini/uvis/access.html
+++ b/website/cassini/uvis/access.html
@@ -10,8 +10,8 @@ tabs: cassini_uvis
     derived from UVIS stellar occultation data obtained during the prime mission (2004-2008).
     The data include ring radial profiles at 1 and 10 km resolution from more than 50 UVIS stellar occultations.
 
-  * You may browse the dataset [COUVIS_8001](/viewmaster/volumes/COUVIS_8xxx), or download the entire dataset
-    [COUVIS_8001 tar.gz](/viewmaster/archives-volumes/COUVIS_8xxx/).
+  * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx){:target="_blank"}, or download the entire dataset
+    [COUVIS_8001 tar.gz]({{ site.viewmaster_url }}archives-volumes/COUVIS_8xxx/).
 
   * Version 2 of this dataset, which corrects the known errors and expands the dataset coverage to the entire mission,
     is expected to be available in early 2019.
@@ -38,7 +38,7 @@ You can **Search** for UVIS data using **[OPUS]({{ site.opus_url }}){:target="_b
 
   * Since UVIS observations contain a lot of information which is target
     dependent, representing that information with reasonable fidelity is complex.
-    Consequently we have provided a [key for the UVIS previews](UVIS_previews.txt){:target="_blank"}.
+    Consequently we have provided a [key for the UVIS previews]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Preview-Interpretation-Guide.txt){:target="_blank"}.
 
   * The following tables provide links to individual **volumes**.
 
@@ -55,7 +55,7 @@ The bundled volumes are provided in [tar.gz](/help/targz.html) format.
     * Browse Images will take you to a directory containing sub-directories of preview images for each UVIS cube in the volume.
 
 The preview images contain a wealth of information. The key for the preview
-images is in [UVIS_previews.txt](UVIS_previews.txt){:target="_blank"}.
+images is in [key for the UVIS previews]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Preview-Interpretation-Guide.txt){:target="_blank"}.
 
 ### Data sets and the volumes which contain them
 

--- a/website/cassini/uvis/access.html
+++ b/website/cassini/uvis/access.html
@@ -11,7 +11,7 @@ tabs: cassini_uvis
     The data include ring radial profiles at 1 and 10 km resolution from more than 50 UVIS stellar occultations.
 
   * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx){:target="_blank"}, or download the entire dataset
-    [COUVIS_8001 tar.gz]({{ site.viewmaster_url }}archives-volumes/COUVIS_8xxx/).
+    [COUVIS_8001 tar.gz]({{ site.holdings_url }}archives-volumes/COUVIS_8xxx/COUVIS_8001.tar.gz) (438 MB).
 
   * Version 2 of this dataset, which corrects the known errors and expands the dataset coverage to the entire mission,
     is expected to be available in early 2019.

--- a/website/cassini/uvis/access.html
+++ b/website/cassini/uvis/access.html
@@ -18,7 +18,7 @@ tabs: cassini_uvis
 
 ### Getting the Data You Want
 
-You can **Search** for UVIS data using **[OPUS]({{ site.opus_url }}){:target="_blank"}** (Outer Planets Unified Search)
+You can **Search** for UVIS data using **[OPUS]({{ site.opus_url }}/instrument=Cassini+UVIS&mission=Cassini&widgets=mission,instrument,planet,target){:target="_blank"}** (Outer Planets Unified Search)
 
   * The tables below contain links to all of the available raw UVIS data, including all four 'phases': calibration, cruise,
     Jupiter, and Saturn data. This data is also available through the [Atmospheres Node](//pds-atmospheres.nmsu.edu/data_and_services/atmospheres_data/Cassini/inst-uvis.html){:target="_blank"}.

--- a/website/cassini/uvis/finding.html
+++ b/website/cassini/uvis/finding.html
@@ -65,12 +65,11 @@ a link to the volume.
 
 ###  4\. Volume INDEX Files
 
-Each volume has an [INDEX]({{ site.viewmaster_url }}COUVIS_0xxx/COUVIS_0060/){:target="_blank"} subdirectory
-containing several files including:
+Each volume has an COUVIS_0xxx/COUVIS_00xx/INDEX/ subdirectory containing several files including:
 
-  * [INDXINFO.TXT](INDXINFO.TXT){:target="_blank"}: summarizes the structure and contents of the other two files in the INDEX subdirectory.
+  * [INDXINFO.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/INDEX/INDXINFO.TXT){:target="_blank"}: summarizes the structure and contents of the other two files in the INDEX subdirectory.
 
 **Users are strongly encouraged to read an INDXINFO.TXT before working with the INDEX files.**
-  * [INDEX.TAB](COUVIS_0002_INDEX_TAB.txt){:target="_blank"}: an ASCII table file with one row for each data file on the volume. For Cassini UVIS, each index table approximately 45 columns. This example is from disk COUVIS_0002.
+  * [INDEX.TAB]({{ site.holdings_url }}metadata/COUVIS_0xxx/COUVIS_0999/COUVIS_0999_index.tab){:target="_blank"}: an ASCII table file with one row for each data file on the volume. For Cassini UVIS, each index table approximately 45 columns. This example is from disk COUVIS_0002.
 
-  * [INDEX.LBL](INDEX_LBL.txt){:target="_blank"}: the detached PDS label file for the INDEX.TAB file. This is a text file giving names and definitions of all the columns in the index.
+  * [INDEX.LBL]({{ site.holdings_url }}metadata/COUVIS_0xxx/COUVIS_0999/COUVIS_0999_index.lbl){:target="_blank"}: the detached PDS label file for the INDEX.TAB file. This is a text file giving names and definitions of all the columns in the index.

--- a/website/cassini/uvis/finding.html
+++ b/website/cassini/uvis/finding.html
@@ -65,7 +65,7 @@ a link to the volume.
 
 ###  4\. Volume INDEX Files
 
-Each volume has an [INDEX](/link/volumes/COUVIS_0xxx/COUVIS_0004/){:target="_blank"} subdirectory
+Each volume has an [INDEX]({{ site.viewmaster_url }}COUVIS_0xxx/COUVIS_0060/){:target="_blank"} subdirectory
 containing several files including:
 
   * [INDXINFO.TXT](INDXINFO.TXT){:target="_blank"}: summarizes the structure and contents of the other two files in the INDEX subdirectory.

--- a/website/cassini/uvis/finding.html
+++ b/website/cassini/uvis/finding.html
@@ -65,11 +65,7 @@ a link to the volume.
 
 ###  4\. Volume INDEX Files
 
-Each volume has an COUVIS_0xxx/COUVIS_00xx/INDEX/ subdirectory containing several files including:
+All instruments provide some form of metadata index files in the folder called INDEX within each PDS3 volume. 
 
-  * [INDXINFO.TXT]({{ site.holdings_url }}volumes/COUVIS_0xxx/COUVIS_0060/INDEX/INDXINFO.TXT){:target="_blank"}: summarizes the structure and contents of the other two files in the INDEX subdirectory.
-
-**Users are strongly encouraged to read an INDXINFO.TXT before working with the INDEX files.**
-  * [INDEX.TAB]({{ site.holdings_url }}metadata/COUVIS_0xxx/COUVIS_0999/COUVIS_0999_index.tab){:target="_blank"}: an ASCII table file with one row for each data file on the volume. For Cassini UVIS, each index table approximately 45 columns. This example is from disk COUVIS_0002.
-
-  * [INDEX.LBL]({{ site.holdings_url }}metadata/COUVIS_0xxx/COUVIS_0999/COUVIS_0999_index.lbl){:target="_blank"}: the detached PDS label file for the INDEX.TAB file. This is a text file giving names and definitions of all the columns in the index.
+However, RMS Node using later available SPICE kernels, provides extensive metadata tables for this instrument. 
+They are available here: [metadata/COUVIS_0xxx]({{ site.viewmaster_url }}metadata/COUVIS_0xxx/COUVIS_0999){:target="_blank"}.

--- a/website/cassini/uvis/index.html
+++ b/website/cassini/uvis/index.html
@@ -4,7 +4,7 @@ layout_style: default
 tabs: cassini_uvis
 ---
   
-![\[RING PSEUDO-IMAGE\]](PIA05075.jpg)
+![\[RING PSEUDO-IMAGE\]](//pds-rings.seti.org/cassini/uvis/PIA05075.jpg)
 
 ### Overview
 
@@ -25,7 +25,7 @@ relative abundance of deuterium and hydrogen from their lyman-alpha emission.
 
   * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}, or 
     download the entire dataset 
-    [COUVIS_8001 tar.gz]({{ site.viewmaster_url }}archives-volumes/COUVIS_8xxx/). 
+    [COUVIS_8001 tar.gz]({{ site.holdings_url }}archives-volumes/COUVIS_8xxx/COUVIS_8001.tar.gz) (438 MB). 
 
   * Version 2 of this dataset, corrects the known errors and expands the dataset coverage 
     to the entire mission. It includes:

--- a/website/cassini/uvis/index.html
+++ b/website/cassini/uvis/index.html
@@ -23,9 +23,9 @@ relative abundance of deuterium and hydrogen from their lyman-alpha emission.
     occultation data is now available. The data include ring radial profiles at 1 and 10 km 
     resolution from more than 200 UVIS stellar occultations. 
 
-  * You may browse the dataset [COUVIS_8001](/viewmaster/volumes/COUVIS_8xxx/COVIMS_8001/), or 
+  * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COVIMS_8001/){:target="_blank"}, or 
     download the entire dataset 
-    [COUVIS_8001 tar.gz](/viewmaster/archives-volumes/COUVIS_8xxx/). 
+    [COUVIS_8001 tar.gz]({{ site.viewmaster_url }}archives-volumes/COUVIS_8xxx/). 
 
   * Version 2 of this dataset, corrects the known errors and expands the dataset coverage 
     to the entire mission. It includes:
@@ -42,7 +42,7 @@ relative abundance of deuterium and hydrogen from their lyman-alpha emission.
     
 ###  Cassini UVIS Data Users Guide
 
-  * **July 2018.** An updated version of the **<a href="1-UVIS_Users_Guide_-2018-Jan 15-For PDS-REV-2018-07-06.pdf" target="_blank">UVIS User Guide</a>** is available. 
+  * **July 2018.** An updated version of the **[UVIS User Guide]({{ site.holdings_url }}documents/COUVIS_0xxx/UVIS-Users-Guide.pdf){:target="_blank"}** is available. 
 
 ###  The UVIS Tabs
 

--- a/website/cassini/uvis/index.html
+++ b/website/cassini/uvis/index.html
@@ -23,7 +23,7 @@ relative abundance of deuterium and hydrogen from their lyman-alpha emission.
     occultation data is now available. The data include ring radial profiles at 1 and 10 km 
     resolution from more than 200 UVIS stellar occultations. 
 
-  * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COVIMS_8001/){:target="_blank"}, or 
+  * You may browse the dataset [COUVIS_8001]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/){:target="_blank"}, or 
     download the entire dataset 
     [COUVIS_8001 tar.gz]({{ site.viewmaster_url }}archives-volumes/COUVIS_8xxx/). 
 

--- a/website/cassini/uvis/index.html
+++ b/website/cassini/uvis/index.html
@@ -4,7 +4,7 @@ layout_style: default
 tabs: cassini_uvis
 ---
   
-![\[RING PSEUDO-IMAGE\]](//pds-rings.seti.org/cassini/uvis/PIA05075.jpg)
+![\[RING PSEUDO-IMAGE\]]({{ site.assets_url }}cassini/uvis/PIA05075.jpg)
 
 ### Overview
 
@@ -32,13 +32,14 @@ relative abundance of deuterium and hydrogen from their lyman-alpha emission.
     
     * reprocessed versions of the material contained in the original version;
     
-    * in the document directory: the Cassini_UVIS_Ring_Occultation_Atlas, an eight volume document that contains tabular 
+    * in the [document]({{ site.viewmaster_url }}volumes/COUVIS_8xxx/COUVIS_8001/document){:target="_blank"} directory, 
+      the [Cassini_UVIS_Ring_Occultation_Atlas]({{ site.holdings_url }}volumes/COUVIS_8xxx/COUVIS_8001/document/Cassini_UVIS_Ring_Occultation_Atlas.lbl){:target="_blank"}, an eight volume document that contains tabular 
       lists of all UVIS stellar occultations including the star name, rev number, indication of 
       ingress (I) or egress (E), date of the occultation, duration of the occultation, radial range 
       coverage and elevation angle of the star. In addition, for each occultation the Atlas contains plots 
       showing the occultation geometry and raw signal vs. radius.
       
-    * Details of the data processing involved in the production of this data set are provided in COLWELLETAL2010.
+    * Details of the data processing involved in the production of this data set are provided in [COLWELLETAL2010](//doi.org/10.1088/0004-6256/140/6/1569){:target="_blank"}.
     
 ###  Cassini UVIS Data Users Guide
 

--- a/website/cassini/uvis/occ.html
+++ b/website/cassini/uvis/occ.html
@@ -1,7 +1,0 @@
----
-layout: base
-layout_style: default
----
-
-
-

--- a/website/cassini/uvis/software.html
+++ b/website/cassini/uvis/software.html
@@ -6,16 +6,15 @@ tabs: cassini_uvis
 
 ## Software
 
-**Three types of software are available for general use.** Calibration and data viewing software are included in the Software directory on each volume. You can download an [entire UVIS SOFTWARE directory](./uvis_software.tar.gz) here. 
+**Three types of software are available for general use.** Calibration and data viewing software are included in the Software directory on each volume. 
+You can download an entire UVIS SOFTWARE directory [here]({{ site.assets_url}}cassini/uvis/uvis_software.tar.gz) (686 KB).
 
 ### 1\. Calibration Software
 
 * Calibration is done by combining data Qubes with their corresponding calibration objects. Both are provided on each volume.
 
-The software used to generate the calibration objects is included on each
-volume for reference, and can be found in the
-[SOFTWARE]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0004/SOFTWARE/){:target="_blank"} directory. You can download
-an [entire UVIS SOFTWARE directory](./uvis_software.tar.gz) here.
+The software used to generate the calibration objects is included on each volume for reference, and can be found in the
+[SOFTWARE]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0004/SOFTWARE/){:target="_blank"} directory.
 
 ### 2\. Data viewing Software
 

--- a/website/cassini/uvis/software.html
+++ b/website/cassini/uvis/software.html
@@ -14,14 +14,14 @@ tabs: cassini_uvis
 
 The software used to generate the calibration objects is included on each
 volume for reference, and can be found in the
-[SOFTWARE](/link/volumes/COUVIS_0xxx/COUVIS_0004/SOFTWARE/) directory. You can download
+[SOFTWARE]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0004/SOFTWARE/){:target="_blank"} directory. You can download
 an [entire UVIS SOFTWARE directory](./uvis_software.tar.gz) here.
 
 ### 2\. Data viewing Software
 
-* Data can be accessed using software found in the [SOFTWARE/READERS](/link/volumes/COUVIS_0xxx/COUVIS_0004/SOFTWARE/READERS) subdirectory. This subdirectory contains documentation for the installation and use of the software.
+* Data can be accessed using software found in the [SOFTWARE/READERS]({{ site.viewmaster_url }}volumes/COUVIS_0xxx/COUVIS_0060/SOFTWARE/READERS){:target="_blank"} subdirectory. This subdirectory contains documentation for the installation and use of the software.
 
 ### 3\. Data Analysis Software
 
-* UVIS data are compatible with the Integrated Software for Imagers and Spectrometers (ISIS) software package which is available through the <a href="//isis.astrogeology.usgs.gov/" target="_blank">USGS Flagstaff web site.</a>
+* UVIS data are compatible with the Integrated Software for Imagers and Spectrometers (ISIS) software package which is available through the [USGS Flagstaff web site.](//isis.astrogeology.usgs.gov/){:target="_blank"}
 


### PR DESCRIPTION
-Updated the links to use holdings instead of assets
-Updated any assets to use the new markdown variable
-Added file_size to the yaml for COUVIS data tables
-Updated data_table.html to accommodate hover-style file sizes for the tar.gz downloads
-Deleted unused file occ.html
-Deleted local copy of the user guide, as the website now refs the copy in holdings.

fixes #127
also fixes #151 